### PR TITLE
Livepeer: unbodingLock amount fix

### DIFF
--- a/contracts/tenderizer/integrations/livepeer/Livepeer.sol
+++ b/contracts/tenderizer/integrations/livepeer/Livepeer.sol
@@ -102,7 +102,7 @@ contract Livepeer is Tenderizer {
         uint256 unbondingLockID = nextUnbondingLockID;
         nextUnbondingLockID += 1;
 
-        unbondingLocks[_account] = unbondingLock({ id: unbondingLockID, amount: _amount });
+        unbondingLocks[_account] = unbondingLock({ id: unbondingLockID, amount: amount });
 
         emit Unstake(_account, node_, amount);
     }


### PR DESCRIPTION
Geez, missed changing the `amount` from `_amount` while setting it in the unbonding lock last time