### PR TITLE
Matic: cleanup interface

### DIFF
--- a/contracts/tenderizer/integrations/matic/IMatic.sol
+++ b/contracts/tenderizer/integrations/matic/IMatic.sol
@@ -6,8 +6,6 @@ pragma solidity 0.8.4;
 
 // note this contract interface is only for stakeManager use
 interface IMatic {
-    function getLiquidRewards(address user) external view returns (uint256);
-
     function owner() external view returns (address);
 
     function restake() external;
@@ -21,13 +19,6 @@ interface IMatic {
     function exchangeRate() external view returns (uint256);
 
     function validatorId() external view returns (uint256);
-
-    struct Delegator {
-        uint256 shares;
-        uint256 withdrawEpoch;
-    }
-
-    function delegators(address) external view returns (Delegator memory);
 
     function balanceOf(address) external view returns (uint256);
 }

--- a/contracts/tenderizer/integrations/matic/MaticMock.sol
+++ b/contracts/tenderizer/integrations/matic/MaticMock.sol
@@ -8,18 +8,11 @@ contract MaticMock {
     }
 
     IERC20 matic;
-
-    function withdrawRewards() public {}
-
-    function unstakeClaimTokens() public {}
-
-    function getLiquidRewards(address user) public view returns (uint256) {}
+    function owner() external view returns (address) {}
 
     function restake() public {}
 
     function buyVoucher(uint256 _amount, uint256 _minSharesToMint) external {}
-
-    function sellVoucher(uint256 _minClaimAmount) external {}
 
     function sellVoucher_new(uint256 _claimAmount, uint256 _maximumSharesToBurn) external {}
 
@@ -30,11 +23,4 @@ contract MaticMock {
     function validatorId() external view returns (uint256) {}
 
     function balanceOf(address _from) external view returns (uint256) {}
-
-    struct Delegator {
-        uint256 shares;
-        uint256 withdrawEpoch;
-    }
-
-    function delegators(address) external view returns (Delegator memory) {}
 }


### PR DESCRIPTION
Cleanup unused functions in interface to avoid confusion, `delegators(address)` doesn't exist in new contracts.