### PR TITLE
Controller: Make upgradable

### DIFF
--- a/contracts/libs/ReentrancyGuard.sol
+++ b/contracts/libs/ReentrancyGuard.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 internal constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+
+    // Needs to be initialized to _NOT_ENTERED in child contract intialize()/constructor
+    uint256 internal _status;
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+
+        _;
+
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+}

--- a/deploy/02_deploy_tenderizer.ts
+++ b/deploy/02_deploy_tenderizer.ts
@@ -94,7 +94,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) { /
   const controller = await deploy('Controller', {
     from: deployer,
     log: true,
-    args: [process.env.TOKEN, tenderizer.address, tenderToken.address, esp.address]
+    args: [process.env.TOKEN, tenderizer.address, tenderToken.address, esp.address],
+    proxy: {
+      proxyContract: 'EIP173ProxyWithReceive',
+      owner: deployer,
+      methodName: 'initialize'
+    }
   })
 
   const TenderToken: TenderToken = (await ethers.getContractAt('TenderToken', tenderToken.address)) as TenderToken

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,6 +11,7 @@ import '@openzeppelin/hardhat-upgrades'
 // Tools
 import "hardhat-gas-reporter"
 import "solidity-coverage"
+import '@openzeppelin/hardhat-upgrades'
 
 import { HardhatUserConfig } from "hardhat/types"
 


### PR DESCRIPTION
Closes #102 
Constructors aren't allowed with upgradable contracts, and ReentrancyGuard has a contractor, so added the contract to our repo and
- Removed the contructor
- Made _state and _NOT_ENTERED internal (so that they are inherited)
- set _state = _NOT_ENTERED in the initialize function in controller (which was originally done in ReentrancyGuard contructor)

TODO:

- [ ] FIx coverage drop