### PR TITLE
TenderSwap: add SelfPermit and Multicall for permit support

### DIFF
--- a/contracts/helpers/Multicall.sol
+++ b/contracts/helpers/Multicall.sol
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2021 Tenderize <info@tenderize.me>
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+interface IMulticall {
+    /// @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+    /// @dev The `msg.value` should not be trusted for any method callable from multicall.
+    /// @param _data The encoded function data for each of the calls to make to this contract
+    /// @return results The results from each of the calls passed in via data
+    function multicall(bytes[] calldata _data) external payable returns (bytes[] memory results);
+}
+
+/// @title Multicall
+/// @notice Enables calling multiple methods in a single call to the contract
+abstract contract Multicall is IMulticall {
+    /// @inheritdoc IMulticall
+    function multicall(bytes[] calldata _data) public payable override returns (bytes[] memory results) {
+        results = new bytes[](_data.length);
+        for (uint256 i = 0; i < _data.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(_data[i]);
+
+            if (!success) {
+                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
+                if (result.length < 68) revert();
+                assembly {
+                    result := add(result, 0x04)
+                }
+                revert(abi.decode(result, (string)));
+            }
+
+            results[i] = result;
+        }
+    }
+}

--- a/contracts/helpers/SelfPermit.sol
+++ b/contracts/helpers/SelfPermit.sol
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2021 Tenderize <info@tenderize.me>
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol';
+
+/// @title Self Permit
+/// @notice Functionality to call permit on any EIP-2612-compliant token for use in the route
+interface ISelfPermit {
+    /// @notice Permits this contract to spend a given token from `msg.sender`
+    /// @dev The `owner` is always msg.sender and the `spender` is always address(this).
+    /// @param _token The address of the token spent
+    /// @param _value The amount that can be spent of token
+    /// @param _deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+    /// @param _v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+    /// @param _r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+    /// @param _s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+    function selfPermit(
+        address _token,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external payable;
+
+    /// @notice Permits this contract to spend a given token from `msg.sender`
+    /// @dev The `owner` is always msg.sender and the `spender` is always address(this).
+    /// Can be used instead of #selfPermit to prevent calls from failing due to a frontrun of a call to #selfPermit
+    /// @param _token The address of the token spent
+    /// @param _value The amount that can be spent of token
+    /// @param _deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+    /// @param _v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+    /// @param _r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+    /// @param _s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+    function selfPermitIfNecessary(
+        address _token,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external payable;
+}
+
+abstract contract SelfPermit is ISelfPermit {
+    /// @inheritdoc ISelfPermit
+    function selfPermit(
+        address _token,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) public payable override {
+        _selfPermit(_token, _value, _deadline, _v, _r, _s);
+    }
+
+    /// @inheritdoc ISelfPermit
+    function selfPermitIfNecessary(
+        address _token,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external payable override {
+        uint256 allowance = IERC20(_token).allowance(msg.sender, address(this));
+        if ( allowance < _value) _selfPermit(_token, _value-allowance, _deadline, _v, _r, _s);
+    }
+
+    function _selfPermit(
+        address _token,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) public payable {
+        IERC20Permit(_token).permit(msg.sender, address(this), _value, _deadline, _v, _r, _s);
+    }
+}

--- a/contracts/tenderswap/TenderSwap.sol
+++ b/contracts/tenderswap/TenderSwap.sol
@@ -8,6 +8,9 @@ import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
+import {Multicall} from "../helpers/Multicall.sol";
+import {SelfPermit} from "../helpers/SelfPermit.sol";
+
 import "./LiquidityPoolToken.sol";
 import "./SwapUtils.sol";
 import "./ITenderSwap.sol";
@@ -28,7 +31,7 @@ interface IERC20Decimals is IERC20 {
  * as the total supply of the token 'rebases'.
  */
 
-contract TenderSwap is OwnableUpgradeable, ReentrancyGuardUpgradeable, ITenderSwap {
+contract TenderSwap is OwnableUpgradeable, ReentrancyGuardUpgradeable, ITenderSwap, Multicall, SelfPermit {
     using SwapUtils for SwapUtils.Amplification;
     using SwapUtils for SwapUtils.PooledToken;
     using SwapUtils for SwapUtils.FeeParams;


### PR DESCRIPTION
- Adds `Multicall` and `Selfpermit` to helpers. 

- Adds the above to `TenderSwap`

This enables adding liquidity and swapping with signature based approvals.

Fixes #162 
Fixes #163 
Fixes #167 