### PR TITLE
Graph: Null check shares

### DIFF
--- a/contracts/tenderizer/integrations/graph/Graph.sol
+++ b/contracts/tenderizer/integrations/graph/Graph.sol
@@ -162,6 +162,8 @@ contract Graph is Tenderizer {
         uint256 totalShares = delPool.shares;
         uint256 totalTokens = delPool.tokens;
 
+        if (totalShares == 0) return;
+
         uint256 stake = (delShares * totalTokens) / totalShares;
 
         Tenderizer._processNewStake(stake);

--- a/contracts/test/GraphMock.sol
+++ b/contracts/test/GraphMock.sol
@@ -66,12 +66,12 @@ contract GraphMock is MockStaking {
     function delegationPools(address _indexer) external view returns (DelegationPool memory) {
         return
             DelegationPool({
-                tokens: staked == 0 ? 1 : staked,
+                tokens: staked,
                 cooldownBlocks: 0,
                 indexingRewardCut: 0,
                 queryFeeCut: 0,
                 updatedAtBlock: 0,
-                shares: staked == 0 ? 1 : staked
+                shares: staked
             });
     }
 

--- a/test/integration/audius.test.ts
+++ b/test/integration/audius.test.ts
@@ -8,6 +8,8 @@ import { solidity } from 'ethereum-waffle'
 import { Deployment } from 'hardhat-deploy/dist/types'
 import { BigNumber } from '@ethersproject/bignumber'
 
+import beforeInitialDepsoits from './behaviors/beforeInitialDeposits.behavior'
+import addInitialDeposits from './behaviors/addInitialDeposits'
 import initialStateTests from './behaviors/initialState.behavior'
 import depositTests from './behaviors/deposit.behavior'
 import stakeTests from './behaviors/stake.behavior'
@@ -25,8 +27,6 @@ import unlockTests from './behaviors/govBasedUnlock.behavior'
 import withdrawTests from './behaviors/govBasedWithdrawal.behavior'
 import upgradeTests from './behaviors/upgrade.behavior'
 import setterTests from './behaviors/setters.behavior'
-
-import { getCurrentBlockTimestamp } from '../util/evm'
 
 chai.use(solidity)
 
@@ -105,85 +105,78 @@ describe('Audius Integration Test', () => {
     // Set contract variables
     await this.Tenderizer.setProtocolFee(protocolFeesPercent)
     await this.Tenderizer.setLiquidityFee(liquidityFeesPercent)
-
-    // Deposit initial stake
-    await this.Steak.approve(this.Tenderizer.address, this.initialStake)
-    await this.Tenderizer.deposit(this.initialStake)
-    // await this.Tenderizer.claimRewards()
-    // Add initial liquidity
-    await this.Steak.approve(this.TenderSwap.address, this.initialStake)
-    await this.TenderToken.approve(this.TenderSwap.address, this.initialStake)
-    const lpTokensOut = await this.TenderSwap.calculateTokenAmount([this.initialStake, this.initialStake], true)
-    await this.TenderSwap.addLiquidity([this.initialStake, this.initialStake], lpTokensOut, (await getCurrentBlockTimestamp()) + 1000)
-    console.log('added liquidity')
-    console.log('calculated', lpTokensOut.toString(), 'actual', (await this.LpToken.balanceOf(this.deployer)).toString())
-    await this.LpToken.approve(this.TenderFarm.address, lpTokensOut)
-    await this.TenderFarm.farm(lpTokensOut)
-    console.log('farmed LP tokens')
   })
 
   // Run tests
-  describe('Initial State', initialStateTests.bind(this))
-  describe('Deposit', depositTests.bind(this))
-  describe('Stake', stakeTests.bind(this))
+  describe('Before intial deposits', beforeInitialDepsoits.bind(this))
 
-  let liquidityFees: BigNumber
-  let protocolFees: BigNumber
-  let newStake: BigNumber
-  describe('Rebases', async function () {
-    context('Positive Rebase', async function () {
-      before(async function () {
-        this.increase = ethers.utils.parseEther('10')
-        liquidityFees = percOf2(this.increase, liquidityFeesPercent)
-        protocolFees = percOf2(this.increase, protocolFeesPercent)
-        newStake = this.deposit.add(this.initialStake).add(this.increase)
-        this.newStakeMinusFees = newStake.sub(liquidityFees.add(protocolFees))
-
-        // set increase on mock
-        await this.StakingContract.setStaked(this.increase.add(await this.StakingContract.staked()))
-
-        // With mock values set correctly, adjust increase with fees
-        // for assertions
-        this.increase = this.increase.sub(protocolFees.add(liquidityFees))
-      })
-      describe('Stake increases', stakeIncreaseTests.bind(this))
-    })
-
-    context('Neutral Rebase', async function () {
-      before(async function () {
-        this.stakeMinusFees = newStake.sub(liquidityFees.add(protocolFees))
-      })
-      describe('Stake stays the same', stakeStaysSameTests.bind(this))
-    })
-
-    context('Negative Rebase', async function () {
-      before(async function () {
-        const stake = await this.StakingContract.staked()
-        this.decrease = ethers.utils.parseEther('10')
-        // reduced stake is current stake - 100 from rewards previously
-        const reducedStake = stake.sub(this.decrease)
-        this.expectedCP = reducedStake.sub(liquidityFees).sub(protocolFees)
-        // reduce staked on mock
-        await this.StakingContract.setStaked(reducedStake)
-      })
-      describe('Stake decreases', stakeDecreaseTests.bind(this))
-    })
-  })
-
-  describe('Collect fees', protocolFeeTests.bind(this))
-  describe('Collect Liquidity fees', liquidityFeeTests.bind(this))
-  describe('Swap', swapTests.bind(this))
-
-  describe('Unlock and Withdraw', async function () {
+  describe('After initial deposits', async function () {
     before(async function () {
-      this.withdrawAmount = await this.TenderToken.balanceOf(this.deployer)
-      await this.StakingContract.setStaked(
-        await this.Tenderizer.totalStakedTokens()
-      )
+      await addInitialDeposits(this)
     })
-    describe('Unstake', unlockTests.bind(this))
-    describe('Withdrawl', withdrawTests.bind(this))
+
+    describe('Initial State', initialStateTests.bind(this))
+    describe('Deposit', depositTests.bind(this))
+    describe('Stake', stakeTests.bind(this))
+
+    let liquidityFees: BigNumber
+    let protocolFees: BigNumber
+    let newStake: BigNumber
+    describe('Rebases', async function () {
+      context('Positive Rebase', async function () {
+        before(async function () {
+          this.increase = ethers.utils.parseEther('10')
+          liquidityFees = percOf2(this.increase, liquidityFeesPercent)
+          protocolFees = percOf2(this.increase, protocolFeesPercent)
+          newStake = this.deposit.add(this.initialStake).add(this.increase)
+          this.newStakeMinusFees = newStake.sub(liquidityFees.add(protocolFees))
+
+          // set increase on mock
+          await this.StakingContract.setStaked(this.increase.add(await this.StakingContract.staked()))
+
+          // With mock values set correctly, adjust increase with fees
+          // for assertions
+          this.increase = this.increase.sub(protocolFees.add(liquidityFees))
+        })
+        describe('Stake increases', stakeIncreaseTests.bind(this))
+      })
+
+      context('Neutral Rebase', async function () {
+        before(async function () {
+          this.stakeMinusFees = newStake.sub(liquidityFees.add(protocolFees))
+        })
+        describe('Stake stays the same', stakeStaysSameTests.bind(this))
+      })
+
+      context('Negative Rebase', async function () {
+        before(async function () {
+          const stake = await this.StakingContract.staked()
+          this.decrease = ethers.utils.parseEther('10')
+          // reduced stake is current stake - 100 from rewards previously
+          const reducedStake = stake.sub(this.decrease)
+          this.expectedCP = reducedStake.sub(liquidityFees).sub(protocolFees)
+          // reduce staked on mock
+          await this.StakingContract.setStaked(reducedStake)
+        })
+        describe('Stake decreases', stakeDecreaseTests.bind(this))
+      })
+    })
+
+    describe('Collect fees', protocolFeeTests.bind(this))
+    describe('Collect Liquidity fees', liquidityFeeTests.bind(this))
+    describe('Swap', swapTests.bind(this))
+
+    describe('Unlock and Withdraw', async function () {
+      before(async function () {
+        this.withdrawAmount = await this.TenderToken.balanceOf(this.deployer)
+        await this.StakingContract.setStaked(
+          await this.Tenderizer.totalStakedTokens()
+        )
+      })
+      describe('Unstake', unlockTests.bind(this))
+      describe('Withdrawl', withdrawTests.bind(this))
+    })
+    describe('Upgrades', upgradeTests.bind(this))
+    describe('Setting contract variables', setterTests.bind(this))
   })
-  describe('Upgrades', upgradeTests.bind(this))
-  describe('Setting contract variables', setterTests.bind(this))
 })

--- a/test/integration/behaviors/addInitialDeposits.ts
+++ b/test/integration/behaviors/addInitialDeposits.ts
@@ -1,0 +1,19 @@
+import { getCurrentBlockTimestamp } from '../../util/evm'
+
+export default async function depositTenderizer (ctx: any) {
+    // Deposit initial stake
+    await ctx.Steak.approve(ctx.Tenderizer.address, ctx.initialStake)
+    await ctx.Tenderizer.deposit(ctx.initialStake)
+    // await ctx.Tenderizer.claimRewards()
+    // Add initial liquidity
+    const tokensAfterTax = ctx.initialStake.sub(ctx.initialStake.mul(ctx.DELEGATION_TAX).div(ctx.MAX_PPM))
+    await ctx.Steak.approve(ctx.TenderSwap.address, tokensAfterTax)
+    await ctx.TenderToken.approve(ctx.TenderSwap.address, tokensAfterTax)
+    const lpTokensOut = await ctx.TenderSwap.calculateTokenAmount([tokensAfterTax, tokensAfterTax], true)
+    await ctx.TenderSwap.addLiquidity([tokensAfterTax, tokensAfterTax], lpTokensOut, (await getCurrentBlockTimestamp()) + 1000)
+    console.log('added liquidity')
+    console.log('calculated', lpTokensOut.toString(), 'actual', (await ctx.LpToken.balanceOf(ctx.deployer)).toString())
+    await ctx.LpToken.approve(ctx.TenderFarm.address, lpTokensOut)
+    await ctx.TenderFarm.farm(lpTokensOut)
+    console.log('farmed LP tokens')
+}

--- a/test/integration/behaviors/beforeInitialDeposits.behavior.ts
+++ b/test/integration/behaviors/beforeInitialDeposits.behavior.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai'
+
+export default function suite () {
+  let ctx: any
+  before(async function () {
+    ctx = this.test?.ctx
+  })
+
+  it('current principle is 0', async function () {
+    expect(await ctx.Tenderizer.totalStakedTokens()).to.be.eq(0)
+  })
+
+  it('pending fees are 0', async function () {
+    expect(await ctx.Tenderizer.pendingFees()).to.be.eq(0)
+    expect(await ctx.Tenderizer.pendingLiquidityFees()).to.be.eq(0)
+  })
+
+  it('claimRewards() does not revert', async function () {
+    await expect(ctx.Tenderizer.claimRewards()).to.be.not.reverted
+  })
+
+  it('collectFees() does not revert', async function () {
+    await expect(ctx.Tenderizer.collectFees()).to.be.not.reverted
+  })
+
+  it('collectLiquidityFees() does not revert', async function () {
+    await expect(ctx.Tenderizer.collectFees()).to.be.not.reverted
+  })
+
+  it('TenderToken supply is 0', async function () {
+    expect(await ctx.TenderToken.totalSupply()).to.be.eq(0)
+  })
+
+  it('LP Token balances are 0', async function () {
+    expect(await ctx.TenderSwap.getToken0Balance()).to.be.eq(0)
+    expect(await ctx.TenderSwap.getToken1Balance()).to.be.eq(0)
+  })
+
+  it('LPToken supply is 0', async function () {
+    expect(await ctx.LpToken.totalSupply()).to.be.eq(0)
+  })
+}

--- a/test/integration/livepeer.test.ts
+++ b/test/integration/livepeer.test.ts
@@ -13,6 +13,8 @@ import {
 import { Deployment } from 'hardhat-deploy/dist/types'
 import { BigNumber } from '@ethersproject/bignumber'
 
+import beforeInitialDepsoits from './behaviors/beforeInitialDeposits.behavior'
+import addInitialDeposits from './behaviors/addInitialDeposits'
 import initialStateTests from './behaviors/initialState.behavior'
 import depositTests from './behaviors/deposit.behavior'
 import stakeTests from './behaviors/stake.behavior'
@@ -35,7 +37,6 @@ import userBasedWithdrawalTests from './behaviors/userBasedWithdrawal.behavior'
 import upgradeTests from './behaviors/upgrade.behavior'
 import setterTests from './behaviors/setters.behavior'
 import { percOf2 } from '../util/helpers'
-import { getCurrentBlockTimestamp } from '../util/evm'
 
 chai.use(solidity)
 
@@ -140,103 +141,96 @@ describe('Livepeer Integration Test', () => {
     await this.Tenderizer.setProtocolFee(protocolFeesPercent)
     await this.Tenderizer.setLiquidityFee(liquidityFeesPercent)
     await this.Tenderizer.setUniswapRouter(UniswapRouterMock.address)
-
-    // Deposit initial stake
-    await this.Steak.approve(this.Tenderizer.address, this.initialStake)
-    await this.Tenderizer.deposit(this.initialStake)
-    // await this.Tenderizer.claimRewards()
-    // Add initial liquidity
-    await this.Steak.approve(this.TenderSwap.address, this.initialStake)
-    await this.TenderToken.approve(this.TenderSwap.address, this.initialStake)
-    const lpTokensOut = await this.TenderSwap.calculateTokenAmount([this.initialStake, this.initialStake], true)
-    await this.TenderSwap.addLiquidity([this.initialStake, this.initialStake], lpTokensOut, (await getCurrentBlockTimestamp()) + 1000)
-    console.log('added liquidity')
-    console.log('calculated', lpTokensOut.toString(), 'actual', (await this.LpToken.balanceOf(this.deployer)).toString())
-    await this.LpToken.approve(this.TenderFarm.address, lpTokensOut)
-    await this.TenderFarm.farm(lpTokensOut)
-    console.log('farmed LP tokens')
   })
 
   // Run tests
-  describe('Initial State', initialStateTests.bind(this))
-  describe('Deposit', depositTests.bind(this))
-  describe('Stake', stakeTests.bind(this))
+  describe('Before intial deposits', beforeInitialDepsoits.bind(this))
 
-  const swappedLPTRewards = ethers.utils.parseEther('10')
-  let liquidityFees: BigNumber
-  let protocolFees: BigNumber
-  let newStake: BigNumber
-  describe('Rebases', async function () {
-    context('Positive Rebase', async function () {
-      before(async function () {
-        this.increase = ethers.utils.parseEther('90')
-        liquidityFees = percOf2(this.increase.add(swappedLPTRewards), liquidityFeesPercent)
-        protocolFees = percOf2(this.increase.add(swappedLPTRewards), protocolFeesPercent)
-        newStake = this.deposit.add(this.initialStake).add(this.increase)
-        this.newStakeMinusFees = newStake.add(swappedLPTRewards).sub(liquidityFees.add(protocolFees))
-
-        // set increase on mock
-        await this.StakingContract.setStaked(this.increase.add(await this.StakingContract.staked()))
-
-        // With mock values set correctly, adjust increase with fees
-        // for assertions
-        this.increase = this.increase.add(swappedLPTRewards).sub(protocolFees.add(liquidityFees))
-
-        // Set secondary rewards
-        await this.StakingContract.setSecondaryRewards(swappedLPTRewards)
-        WethMock.smocked.deposit.will.return()
-        WethMock.smocked.approve.will.return.with(true)
-        UniswapRouterMock.smocked.exactInputSingle.will.return.with(swappedLPTRewards)
-      })
-      describe('Stake increases', stakeIncreaseTests.bind(this))
+  describe('After initial deposits', async function () {
+    before(async function () {
+      await addInitialDeposits(this)
     })
 
-    context('Neutral Rebase', async function () {
-      before(async function () {
-        UniswapRouterMock.smocked.exactInputSingle.will.return.with(ethers.constants.Zero)
-        this.stakeMinusFees = newStake.add(swappedLPTRewards).sub(liquidityFees.add(protocolFees))
-      })
-      describe('Stake stays the same', stakeStaysSameTests.bind(this))
-    })
+    describe('Initial State', initialStateTests.bind(this))
+    describe('Deposit', depositTests.bind(this))
+    describe('Stake', stakeTests.bind(this))
 
-    context('Negative Rebase', async function () {
-      before(async function () {
-        const stake = await this.StakingContract.staked()
-        this.decrease = ethers.utils.parseEther('10')
-        // reduced stake is current stake - 90 from rewards previously
-        const reducedStake = stake.sub(this.decrease)
-        this.expectedCP = reducedStake.sub(liquidityFees).sub(protocolFees)
-        // reduce staked on mock
-        await this.StakingContract.setStaked(reducedStake)
-      })
-      describe('Stake decreases', stakeDecreaseTests.bind(this))
-    })
-  })
-
-  describe('Collect fees', protocolFeeTests.bind(this))
-  describe('Collect Liquidity fees', liquidityFeeTests.bind(this))
-  describe('Swap', swapTests.bind(this))
-
-  describe('Unlock and Withdraw', async function () {
-    describe('User unlock', userBasedUnlockByUser.bind(this))
-    describe('Gov unlock', async function () {
-      context('Zero stake', async function () {
+    const swappedLPTRewards = ethers.utils.parseEther('10')
+    let liquidityFees: BigNumber
+    let protocolFees: BigNumber
+    let newStake: BigNumber
+    describe('Rebases', async function () {
+      context('Positive Rebase', async function () {
         before(async function () {
-          await this.StakingContract.setStaked(0)
+          this.increase = ethers.utils.parseEther('90')
+          liquidityFees = percOf2(this.increase.add(swappedLPTRewards), liquidityFeesPercent)
+          protocolFees = percOf2(this.increase.add(swappedLPTRewards), protocolFeesPercent)
+          newStake = this.deposit.add(this.initialStake).add(this.increase)
+          this.newStakeMinusFees = newStake.add(swappedLPTRewards).sub(liquidityFees.add(protocolFees))
+
+          // set increase on mock
+          await this.StakingContract.setStaked(this.increase.add(await this.StakingContract.staked()))
+
+          // With mock values set correctly, adjust increase with fees
+          // for assertions
+          this.increase = this.increase.add(swappedLPTRewards).sub(protocolFees.add(liquidityFees))
+
+          // Set secondary rewards
+          await this.StakingContract.setSecondaryRewards(swappedLPTRewards)
+          WethMock.smocked.deposit.will.return()
+          WethMock.smocked.approve.will.return.with(true)
+          UniswapRouterMock.smocked.exactInputSingle.will.return.with(swappedLPTRewards)
         })
-        describe('No pending stake', govUnbondRevertIfNoStake.bind(this))
+        describe('Stake increases', stakeIncreaseTests.bind(this))
       })
-      context('>0 Stake', async function () {
+
+      context('Neutral Rebase', async function () {
         before(async function () {
-          await this.StakingContract.setStaked(
-            await this.Tenderizer.totalStakedTokens()
-          )
+          UniswapRouterMock.smocked.exactInputSingle.will.return.with(ethers.constants.Zero)
+          this.stakeMinusFees = newStake.add(swappedLPTRewards).sub(liquidityFees.add(protocolFees))
         })
-        describe('Gov unlocks', userBasedUnlockByGov.bind(this))
+        describe('Stake stays the same', stakeStaysSameTests.bind(this))
+      })
+
+      context('Negative Rebase', async function () {
+        before(async function () {
+          const stake = await this.StakingContract.staked()
+          this.decrease = ethers.utils.parseEther('10')
+          // reduced stake is current stake - 90 from rewards previously
+          const reducedStake = stake.sub(this.decrease)
+          this.expectedCP = reducedStake.sub(liquidityFees).sub(protocolFees)
+          // reduce staked on mock
+          await this.StakingContract.setStaked(reducedStake)
+        })
+        describe('Stake decreases', stakeDecreaseTests.bind(this))
       })
     })
-    describe('Withdraw', userBasedWithdrawalTests.bind(this))
+
+    describe('Collect fees', protocolFeeTests.bind(this))
+    describe('Collect Liquidity fees', liquidityFeeTests.bind(this))
+    describe('Swap', swapTests.bind(this))
+
+    describe('Unlock and Withdraw', async function () {
+      describe('User unlock', userBasedUnlockByUser.bind(this))
+      describe('Gov unlock', async function () {
+        context('Zero stake', async function () {
+          before(async function () {
+            await this.StakingContract.setStaked(0)
+          })
+          describe('No pending stake', govUnbondRevertIfNoStake.bind(this))
+        })
+        context('>0 Stake', async function () {
+          before(async function () {
+            await this.StakingContract.setStaked(
+              await this.Tenderizer.totalStakedTokens()
+            )
+          })
+          describe('Gov unlocks', userBasedUnlockByGov.bind(this))
+        })
+      })
+      describe('Withdraw', userBasedWithdrawalTests.bind(this))
+    })
+    describe('Upgrades', upgradeTests.bind(this))
+    describe('Setting contract variables', setterTests.bind(this))
   })
-  describe('Upgrades', upgradeTests.bind(this))
-  describe('Setting contract variables', setterTests.bind(this))
 })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds a null check on `totalShares` such that claimRewards() does not revert when there is nothing staked.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Return if totalStake == 0

**How did you test each of these updates (required)**
claimRewards does not revert when there is no stake


**Does this pull request close any open issues?**
Fixes #190 