### PR TITLE
Audius Mainnet: Mine more blocks before rewards

### DIFF
--- a/test/mainnet/audius.test.ts
+++ b/test/mainnet/audius.test.ts
@@ -203,7 +203,8 @@ describe('Audius Mainnet Fork Test', () => {
 
         // Mine blocks so new round can be initiated
         // Rounds can be initiated only once per week
-        for (let j = 0; j < 40000; j++) {
+        // TODO: Will promise.all() make things fater?
+        for (let j = 0; j < 50000; j++) {
           await hre.ethers.provider.send('evm_mine', [])
         }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Increase the number of blocks mined in order to meet block difference required to generate rewards. Since we're pinned to the latest block, my guess is that when a new round is just initiated the tests fail for sometime, since not enough blocks are mined in order to meet the round length. Slightly increasing this should fix the issue.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Increase the number of blocks mined before rewards


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tests should pass

**Does this pull request close any open issues?**
<!-- Fixes # -->
