### PR TITLE
Matic: check for slashing during undelegation when withdrawing

### DIFF
--- a/contracts/test/LivepeerMock.sol
+++ b/contracts/test/LivepeerMock.sol
@@ -17,6 +17,7 @@ contract LivepeerMock is MockStaking {
     function unbond(uint256 _amount) external reverted(this.unbond.selector) {
         staked -= _amount;
         unstakeLocks[nextUnstakeLockID] = UnstakeLock({ amount: _amount, account: msg.sender });
+        nextUnstakeLockID++;
     }
 
     function rebondFromUnbonded(address _to, uint256 _unbondingLockId) external {

--- a/contracts/test/MaticMock.sol
+++ b/contracts/test/MaticMock.sol
@@ -28,6 +28,7 @@ contract MaticMock is MockStaking {
     {
         staked -= _claimAmount;
         unstakeLocks[nextUnstakeLockID] = UnstakeLock({ amount: _claimAmount, account: msg.sender });
+        nextUnstakeLockID++;
     }
 
     function unstakeClaimTokens_new(uint256 _unbondNonce) external reverted(this.unstakeClaimTokens_new.selector) {

--- a/contracts/test/MockStaking.sol
+++ b/contracts/test/MockStaking.sol
@@ -17,7 +17,7 @@ contract MockStaking {
     }
 
     mapping(uint256 => UnstakeLock) public unstakeLocks;
-    uint256 nextUnstakeLockID;
+    uint256 public nextUnstakeLockID;
 
     mapping(bytes4 => bool) reverts;
 
@@ -40,5 +40,9 @@ contract MockStaking {
 
     function setReverts(bytes4 _sel, bool yn) public {
         reverts[_sel] = yn;
+    }
+
+    function changePendingUndelegation(uint256 _unstakeLockID, uint256 _newAmount) external {
+        unstakeLocks[_unstakeLockID].amount = _newAmount;
     }
 }

--- a/test/integration/audius.test.ts
+++ b/test/integration/audius.test.ts
@@ -174,7 +174,7 @@ describe('Audius Integration Test', () => {
         )
       })
       describe('Unstake', unlockTests.bind(this))
-      describe('Withdrawl', withdrawTests.bind(this))
+      describe('Withdrawal', withdrawTests.bind(this))
     })
     describe('Upgrades', upgradeTests.bind(this))
     describe('Setting contract variables', setterTests.bind(this))

--- a/test/integration/behaviors/addInitialDeposits.ts
+++ b/test/integration/behaviors/addInitialDeposits.ts
@@ -1,19 +1,19 @@
 import { getCurrentBlockTimestamp } from '../../util/evm'
 
 export default async function depositTenderizer (ctx: any) {
-    // Deposit initial stake
-    await ctx.Steak.approve(ctx.Tenderizer.address, ctx.initialStake)
-    await ctx.Tenderizer.deposit(ctx.initialStake)
-    // await ctx.Tenderizer.claimRewards()
-    // Add initial liquidity
-    const tokensAfterTax = ctx.initialStake.sub(ctx.initialStake.mul(ctx.DELEGATION_TAX).div(ctx.MAX_PPM))
-    await ctx.Steak.approve(ctx.TenderSwap.address, tokensAfterTax)
-    await ctx.TenderToken.approve(ctx.TenderSwap.address, tokensAfterTax)
-    const lpTokensOut = await ctx.TenderSwap.calculateTokenAmount([tokensAfterTax, tokensAfterTax], true)
-    await ctx.TenderSwap.addLiquidity([tokensAfterTax, tokensAfterTax], lpTokensOut, (await getCurrentBlockTimestamp()) + 1000)
-    console.log('added liquidity')
-    console.log('calculated', lpTokensOut.toString(), 'actual', (await ctx.LpToken.balanceOf(ctx.deployer)).toString())
-    await ctx.LpToken.approve(ctx.TenderFarm.address, lpTokensOut)
-    await ctx.TenderFarm.farm(lpTokensOut)
-    console.log('farmed LP tokens')
+  // Deposit initial stake
+  await ctx.Steak.approve(ctx.Tenderizer.address, ctx.initialStake)
+  await ctx.Tenderizer.deposit(ctx.initialStake)
+  // await ctx.Tenderizer.claimRewards()
+  // Add initial liquidity
+  const tokensAfterTax = ctx.initialStake.sub(ctx.initialStake.mul(ctx.DELEGATION_TAX).div(ctx.MAX_PPM))
+  await ctx.Steak.approve(ctx.TenderSwap.address, tokensAfterTax)
+  await ctx.TenderToken.approve(ctx.TenderSwap.address, tokensAfterTax)
+  const lpTokensOut = await ctx.TenderSwap.calculateTokenAmount([tokensAfterTax, tokensAfterTax], true)
+  await ctx.TenderSwap.addLiquidity([tokensAfterTax, tokensAfterTax], lpTokensOut, (await getCurrentBlockTimestamp()) + 1000)
+  console.log('added liquidity')
+  console.log('calculated', lpTokensOut.toString(), 'actual', (await ctx.LpToken.balanceOf(ctx.deployer)).toString())
+  await ctx.LpToken.approve(ctx.TenderFarm.address, lpTokensOut)
+  await ctx.TenderFarm.farm(lpTokensOut)
+  console.log('farmed LP tokens')
 }

--- a/test/integration/behaviors/userBasedWithdrawal.behavior.ts
+++ b/test/integration/behaviors/userBasedWithdrawal.behavior.ts
@@ -9,6 +9,9 @@ export default function suite () {
   let ctx: Context
   let withdrawAmount : BigNumber
 
+  let balBefore: BigNumber
+  let balAfter: BigNumber
+
   before(async function () {
     ctx = this.test?.ctx!
   })
@@ -22,11 +25,14 @@ export default function suite () {
   it('withdraw() succeeds', async () => {
     const lock = await ctx.Tenderizer.unstakeLocks(ctx.lockID)
     withdrawAmount = lock.amount
+    balBefore = await ctx.Steak.balanceOf(ctx.signers[2].address)
+
     tx = await (ctx.Tenderizer.connect(ctx.signers[2])).withdraw(ctx.lockID)
+    balAfter = await ctx.Steak.balanceOf(ctx.signers[2].address)
   })
 
   it('increases Steak balance', async () => {
-    expect(await ctx.Steak.balanceOf(ctx.signers[2].address)).to.eq(withdrawAmount)
+    expect(balAfter.sub(balBefore)).to.eq(withdrawAmount)
   })
 
   it('should delete unstakeLock', async () => {
@@ -38,5 +44,24 @@ export default function suite () {
   it('should emit Withdraw event from Tenderizer', async () => {
     expect(tx).to.emit(ctx.Tenderizer, 'Withdraw')
       .withArgs(ctx.signers[2].address, withdrawAmount, ctx.lockID)
+  })
+
+  it('Withdraws correct amount in case of slashing', async () => {
+    switch (ctx.NAME) {
+      case ('matic'): break
+      default:return
+    }
+    const deposit = ethers.utils.parseEther('100')
+    await ctx.Steak.transfer(ctx.signers[4].address, deposit)
+    const Tenderizer_ = ctx.Tenderizer.connect(ctx.signers[4])
+    await ctx.Steak.connect(ctx.signers[4]).approve(Tenderizer_.address, deposit)
+    await Tenderizer_.deposit(deposit)
+    await Tenderizer_.unstake(deposit)
+    ctx.StakingContract.changePendingUndelegation(1, deposit.div(2))
+
+    const balBefore = await ctx.Steak.balanceOf(ctx.signers[4].address)
+    await Tenderizer_.withdraw(1)
+    const balAfter = await ctx.Steak.balanceOf(ctx.signers[4].address)
+    expect(balAfter.sub(balBefore)).to.eq(deposit.div(2))
   })
 }

--- a/test/integration/graph.test.ts
+++ b/test/integration/graph.test.ts
@@ -181,7 +181,7 @@ describe('Graph Integration Test', () => {
         )
       })
       describe('Unstake', unlockTests.bind(this))
-      describe('Withdrawl', withdrawTests.bind(this))
+      describe('Withdrawal', withdrawTests.bind(this))
     })
     describe('Upgrades', upgradeTests.bind(this))
     describe('Setting contract variables', setterTests.bind(this))

--- a/test/integration/livepeer.test.ts
+++ b/test/integration/livepeer.test.ts
@@ -210,8 +210,9 @@ describe('Livepeer Integration Test', () => {
     describe('Collect Liquidity fees', liquidityFeeTests.bind(this))
     describe('Swap', swapTests.bind(this))
 
-    describe('Unlock and Withdraw', async function () {
+    describe('Unlock and Withdrawal', async function () {
       describe('User unlock', userBasedUnlockByUser.bind(this))
+      describe('Withdrawal', userBasedWithdrawalTests.bind(this))
       describe('Gov unlock', async function () {
         context('Zero stake', async function () {
           before(async function () {
@@ -228,7 +229,6 @@ describe('Livepeer Integration Test', () => {
           describe('Gov unlocks', userBasedUnlockByGov.bind(this))
         })
       })
-      describe('Withdraw', userBasedWithdrawalTests.bind(this))
     })
     describe('Upgrades', upgradeTests.bind(this))
     describe('Setting contract variables', setterTests.bind(this))

--- a/test/integration/matic.test.ts
+++ b/test/integration/matic.test.ts
@@ -174,6 +174,7 @@ describe('Matic Integration Test', () => {
     describe('Swap', swapTests.bind(this))
     describe('Unlock and Withdraw', async function () {
       describe('User unlock', userBasedUnlockByUser.bind(this))
+      describe('Withdrawal', userBasedWithdrawalTests.bind(this))
       describe('Gov unlock', async function () {
         context('Zero stake', async function () {
           before(async function () {
@@ -190,7 +191,6 @@ describe('Matic Integration Test', () => {
           describe('Gov unlocks', userBasedUnlockByGov.bind(this))
         })
       })
-      describe('Withdraw', userBasedWithdrawalTests.bind(this))
     })
     describe('Upgrades', upgradeTests.bind(this))
     describe('Setting contract variables', setterTests.bind(this))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Matic slashes pending undelegations, we should accomodate for that when proxying unstakeLocks in the `Tenderizer`. The balance that will be undelegated from Matic in the case of slashing will be lower than what `Tenderizer` would keep as amount. 

**Specific updates (required)**
- Added a balance check before transferring tokens in the Matic Tenderizer in `withdraw`


**How did you test each of these updates (required)**
- Added a specific unit test
