### PR TITLE
Tenderizer: use _calcDepositOut and remove virtual

### DIFF
--- a/contracts/tenderizer/Tenderizer.sol
+++ b/contracts/tenderizer/Tenderizer.sol
@@ -93,7 +93,7 @@ abstract contract Tenderizer is Initializable, ITenderizer, SelfPermit {
         require(_amount > 0, "ZERO_AMOUNT");
 
         // Calculate tenderTokens to be minted
-        uint256 amountOut = calcDepositOut(_amount);
+        uint256 amountOut = _calcDepositOut(_amount);
 
         // mint tenderTokens
         require(tenderToken.mint(msg.sender, amountOut), "TENDER_MINT_FAILED");
@@ -218,7 +218,7 @@ abstract contract Tenderizer is Initializable, ITenderizer, SelfPermit {
     }
 
     /// @inheritdoc ITenderizer
-    function calcDepositOut(uint256 _amountIn) public view virtual override returns (uint256) {
+    function calcDepositOut(uint256 _amountIn) public view override returns (uint256) {
         return _calcDepositOut(_amountIn);
     }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
- Use internal _calcDepositOut
- Remove virtual from the external function

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tests should run

**Does this pull request close any open issues?**
<!-- Fixes # -->
