### PR TITLE
Matic: Align Tenderizer WithdrawLocks with Matic unbond IDs

### DIFF
--- a/contracts/tenderizer/WithdrawalLocks.sol
+++ b/contracts/tenderizer/WithdrawalLocks.sol
@@ -19,6 +19,10 @@ library WithdrawalLocks {
         uint256 nextWithdrawLockID;
     }
 
+    function initialize(Locks storage _lock, uint256 _initialLockID) internal {
+        _lock.nextWithdrawLockID = _initialLockID;
+    }
+
     function unlock(
         Locks storage _lock,
         address _receiver,

--- a/contracts/tenderizer/integrations/matic/IMatic.sol
+++ b/contracts/tenderizer/integrations/matic/IMatic.sol
@@ -21,4 +21,6 @@ interface IMatic {
     function validatorId() external view returns (uint256);
 
     function balanceOf(address) external view returns (uint256);
+
+    function unbondNonces(address) external view returns (uint256);
 }

--- a/contracts/tenderizer/integrations/matic/IMatic.sol
+++ b/contracts/tenderizer/integrations/matic/IMatic.sol
@@ -4,6 +4,11 @@
 
 pragma solidity 0.8.4;
 
+struct DelegatorUnbond {
+    uint256 shares;
+    uint256 withdrawEpoch;
+}
+
 // note this contract interface is only for stakeManager use
 interface IMatic {
     function owner() external view returns (address);
@@ -23,4 +28,8 @@ interface IMatic {
     function balanceOf(address) external view returns (uint256);
 
     function unbondNonces(address) external view returns (uint256);
+
+    function withdrawExchangeRate() external view returns (uint256);
+
+    function unbonds_new(address, uint256) external view returns (DelegatorUnbond memory);
 }

--- a/contracts/tenderizer/integrations/matic/Matic.sol
+++ b/contracts/tenderizer/integrations/matic/Matic.sol
@@ -122,7 +122,9 @@ contract Matic is Tenderizer {
 
         // Check for any slashes during undelegation
         uint256 balBefore = steak.balanceOf(address(this));
-        matic.unstakeClaimTokens_new(_withdrawalID);
+        // Matic locks start at one, see commit 31f410a3feb63ce58a617356185a332e50504402
+        // This change allows one outstanding lock to still be claimed after this commit
+        matic.unstakeClaimTokens_new(_withdrawalID == 0 ? 1 : _withdrawalID);
         uint256 balAfter = steak.balanceOf(address(this));
         require(balAfter >= balBefore, "ZERO_AMOUNT");
         uint256 amount = balAfter - balBefore;

--- a/contracts/tenderizer/integrations/matic/Matic.sol
+++ b/contracts/tenderizer/integrations/matic/Matic.sol
@@ -16,6 +16,8 @@ import "../../WithdrawalLocks.sol";
 
 import { ITenderSwapFactory } from "../../../tenderswap/TenderSwapFactory.sol";
 
+uint256 constant WITHDRAW_LOCK_START = 2; // Starting point for withdraw lock IDs
+
 contract Matic is Tenderizer {
     using WithdrawalLocks for WithdrawalLocks.Locks;
     using SafeERC20 for IERC20;
@@ -55,6 +57,7 @@ contract Matic is Tenderizer {
         );
         maticStakeManager = _matic;
         matic = IMatic(_node);
+        withdrawLocks.initialize(WITHDRAW_LOCK_START);
     }
 
     function setNode(address _node) external override onlyGov {
@@ -62,6 +65,10 @@ contract Matic is Tenderizer {
         emit GovernanceUpdate(GovernanceParameter.NODE, abi.encode(node), abi.encode(_node));
         node = _node;
         matic = IMatic(_node);
+    }
+
+    function setWithdrawLockStart(uint256 _startID) external onlyGov {
+        withdrawLocks.initialize(_startID);
     }
 
     function _deposit(address _from, uint256 _amount) internal override {

--- a/contracts/test/IMaticStakeManager.sol
+++ b/contracts/test/IMaticStakeManager.sol
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2021 Tenderize <info@tenderize.me>
+
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+enum Status {
+    Inactive,
+    Active,
+    Locked,
+    Unstaked
+}
+
+struct Validator {
+    uint256 amount;
+    uint256 reward;
+    uint256 activationEpoch;
+    uint256 deactivationEpoch;
+    uint256 jailTime;
+    address signer;
+    address contractAddress;
+    Status status;
+    uint256 commissionRate;
+    uint256 lastCommissionUpdate;
+    uint256 delegatorsReward;
+    uint256 delegatedAmount;
+    uint256 initialRewardPerStake;
+}
+
+interface IMaticStakeManager {
+    // validator replacement
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
+
+    function confirmAuctionBid(uint256 validatorId, uint256 heimdallFee) external;
+
+    function transferFunds(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
+
+    function delegationDeposit(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
+
+    function unstake(uint256 validatorId) external;
+
+    function totalStakedFor(address addr) external view returns (uint256);
+
+    function stakeFor(
+        address user,
+        uint256 amount,
+        uint256 heimdallFee,
+        bool acceptDelegation,
+        bytes memory signerPubkey
+    ) external;
+
+    function checkSignatures(
+        uint256 blockInterval,
+        bytes32 voteHash,
+        bytes32 stateRoot,
+        address proposer,
+        uint256[3][] calldata sigs
+    ) external returns (uint256);
+
+    function updateValidatorState(uint256 validatorId, int256 amount) external;
+
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    function slash(bytes calldata slashingInfoList) external returns (uint256);
+
+    function validatorStake(uint256 validatorId) external view returns (uint256);
+
+    function currentValidatorSetSize() external view returns (uint256);
+
+    function epoch() external view returns (uint256);
+
+    function getRegistry() external view returns (address);
+
+    function withdrawalDelay() external view returns (uint256);
+
+    function delegatedAmount(uint256 validatorId) external view returns (uint256);
+
+    function decreaseValidatorDelegatedAmount(uint256 validatorId, uint256 amount) external;
+
+    function withdrawDelegatorsReward(uint256 validatorId) external returns (uint256);
+
+    function delegatorsReward(uint256 validatorId) external view returns (uint256);
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
+
+    function updateSigner(uint256 validatorId, bytes memory signerPubkey) external;
+
+    function validators(uint256 validatorId) external view returns (Validator memory);
+}

--- a/contracts/test/MaticMock.sol
+++ b/contracts/test/MaticMock.sol
@@ -7,7 +7,9 @@ contract MaticMock is MockStaking {
     uint256 public constant validatorId = 1;
     uint256 public constant exchangeRate = 100;
 
-    constructor(IERC20 _token) MockStaking(_token) {}
+    constructor(IERC20 _token) MockStaking(_token) {
+        nextUnstakeLockID = 1;
+    }
 
     function owner() external view returns (address) {
         return msg.sender;

--- a/test/integration/behaviors/userBasedUnlock.behavior.ts
+++ b/test/integration/behaviors/userBasedUnlock.behavior.ts
@@ -7,7 +7,7 @@ import { Context } from 'mocha'
 const secondDeposit = ethers.utils.parseEther('10')
 
 // For protocols where unlocks are tracked per user
-export function userBasedUnlockByUser () {
+export function userBasedUnlockByUser() {
   describe('unbond() reverts', async function () {
     let ctx: Context
     beforeEach(async function () {
@@ -71,16 +71,15 @@ export function userBasedUnlockByUser () {
     })
 
     it('should emit Unstake event from Tenderizer', async () => {
-      expect(tx).to.emit(ctx.Tenderizer, 'Unstake')
+      await expect(tx).to.emit(ctx.Tenderizer, 'Unstake')
         .withArgs(ctx.signers[2].address, ctx.NODE, withdrawAmount, ctx.lockID)
     })
   })
 }
 
-export function rescueFunctions () {
+export function rescueFunctions() {
   let tx: Transaction
   let ctx: Context
-  const lockID = 0
   let principleBefore: BigNumber
 
   beforeEach(async function () {
@@ -95,7 +94,7 @@ export function rescueFunctions () {
     })
 
     it('reverts if not called by gov', async () => {
-      await expect(ctx.Tenderizer.connect(ctx.signers[1]).rescueWithdraw(lockID)).to.be.reverted
+      await expect(ctx.Tenderizer.connect(ctx.signers[1]).rescueWithdraw(ctx.lockID)).to.be.reverted
     })
 
     it('current principle stays the same', async () => {
@@ -104,7 +103,7 @@ export function rescueFunctions () {
 
     it('should emit Unstake event from Tenderizer', async () => {
       expect(tx).to.emit(ctx.Tenderizer, 'Unstake')
-        .withArgs(ctx.Tenderizer.address, ctx.NODE, principleBefore, 0)
+        .withArgs(ctx.Tenderizer.address, ctx.NODE, principleBefore, ctx.lockID)
     })
   })
 
@@ -112,11 +111,11 @@ export function rescueFunctions () {
     beforeEach(async function () {
       principleBefore = await ctx.Tenderizer.currentPrincipal()
       await ctx.Tenderizer.rescueUnlock()
-      tx = await ctx.Tenderizer.rescueWithdraw(lockID)
+      tx = await ctx.Tenderizer.rescueWithdraw(ctx.lockID)
     })
 
     it('reverts if not called by gov', async () => {
-      await expect(ctx.Tenderizer.connect(ctx.signers[1]).rescueWithdraw(lockID)).to.be.reverted
+      await expect(ctx.Tenderizer.connect(ctx.signers[1]).rescueWithdraw(ctx.lockID)).to.be.reverted
     })
 
     it('success - increases Steak balance', async () => {
@@ -126,7 +125,7 @@ export function rescueFunctions () {
 
     it('should emit Withdraw event from Tenderizer', async () => {
       expect(tx).to.emit(ctx.Tenderizer, 'Withdraw')
-        .withArgs(ctx.Tenderizer.address, principleBefore, lockID)
+        .withArgs(ctx.Tenderizer.address, principleBefore, ctx.lockID)
     })
   })
 }

--- a/test/integration/matic.test.ts
+++ b/test/integration/matic.test.ts
@@ -100,7 +100,7 @@ describe('Matic Integration Test', () => {
     this.DELEGATION_TAX = BigNumber.from(0)
     this.MAX_PPM = BigNumber.from(1000000)
 
-    this.lockID = 0
+    this.lockID = 1
 
     Matic = await hre.deployments.fixture(['Matic'], {
       keepExistingDeployments: false
@@ -115,6 +115,7 @@ describe('Matic Integration Test', () => {
     // Set contract variables
     await this.Tenderizer.setProtocolFee(protocolFeesPercent)
     await this.Tenderizer.setLiquidityFee(liquidityFeesPercent)
+    await this.Tenderizer.setWithdrawLockStart(this.lockID)
 
     // Matic specific stuff
     this.exchangeRatePrecision = 100

--- a/test/mainnet/matic.test.ts
+++ b/test/mainnet/matic.test.ts
@@ -1,0 +1,168 @@
+// external imports
+import hre, { ethers, config } from 'hardhat'
+
+// local imports
+import { ERC20, IMaticStakeManager, Matic, IMatic, TenderToken, EIP173Proxy } from "../../typechain"
+
+
+// types
+import { Deployment } from 'hardhat-deploy/dist/types'
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { expect } from 'chai'
+
+
+// Config
+const TOKEN_HOLDER = '0x50d669f43b484166680ecc3670e4766cdb0945ce'
+const STEAK_AMOUNT = '100000'
+const MATIC_STAKE_MANAGER = '0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908'
+const MATIC_TOKEN = '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'
+const ALCHEMY_URL = process.env.ALCHEMY_MAINNET
+const TENDERIZE_OWNER = '0x5542b58080FEE48dBE6f38ec0135cE9011519d96'
+
+describe('Matic Mainnet Fork Test', () => {
+    let MaticStakeManager: IMaticStakeManager
+    let ValidatorShare: IMatic
+    let MaticToken: ERC20
+    let Tenderizer: Matic
+
+    // let Matic: { [name: string]: Deployment }
+
+    let signers: SignerWithAddress[]
+    let deployer: string
+
+    // Create new Matic signers
+    // ---------------------------
+    // const newMaticSigners = []
+    // const accounts: any = config.networks.hardhat.accounts;
+
+    const VALIDATOR_ID: number = 8
+    let VALIDATOR_SHARE: string
+
+    before('fork mainnet', async () => {
+        // Fork from mainnet
+        await hre.network.provider.request({
+            method: 'hardhat_reset',
+            params: [{
+                forking: {
+                    jsonRpcUrl: ALCHEMY_URL,
+                    blockNumber: 16239470
+                }
+            }]
+        })
+    })
+
+    before('get signers', async () => {
+        const namedAccs = await hre.getNamedAccounts()
+        signers = await ethers.getSigners()
+
+        deployer = namedAccs.deployer
+    })
+
+    // Change all validator signers
+    before('set up Matic', async () => {
+        MaticToken = (await ethers.getContractAt('ERC20', MATIC_TOKEN)) as ERC20
+        MaticStakeManager = (await ethers.getContractAt('IMaticStakeManager', MATIC_STAKE_MANAGER)) as IMaticStakeManager
+
+        // Get tokens
+        await hre.network.provider.request({
+            method: 'hardhat_impersonateAccount',
+            params: [TOKEN_HOLDER]
+        })
+        await signers[0].sendTransaction({
+            to: TOKEN_HOLDER,
+            value: ethers.utils.parseEther("1")
+        })
+        await MaticToken.connect(await ethers.provider.getSigner(TOKEN_HOLDER)).transfer(deployer, ethers.utils.parseEther(STEAK_AMOUNT).mul(5))
+        await hre.network.provider.request({
+            method: "hardhat_stopImpersonatingAccount",
+            params: [TOKEN_HOLDER],
+        });
+
+        const validator = await MaticStakeManager.validators(VALIDATOR_ID);
+        VALIDATOR_SHARE = validator.contractAddress
+        ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
+
+
+        // Change validator signers
+        // ------------------------
+        // const validatorCount = (await MaticStakeManager.currentValidatorSetSize()).toNumber()
+
+        // for (let i = 0; i < 9; i++) {
+        //     // get signer
+        //     const validator = await MaticStakeManager.validators(i);
+        //     if (i === 8) {
+        //         VALIDATOR_SHARE = validator.contractAddress
+        //         VALIDATOR_ID = i
+        //         VALIDATOR_ADDRESS = validator.signer
+        //         ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
+        //     }
+
+        //     // impersonate
+        //     await hre.network.provider.request({
+        //         method: 'hardhat_impersonateAccount',
+        //         params: [validator.signer]
+        //     })
+        //     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${i}`);
+        //     const signerPubKey = wallet.publicKey
+        //     newMaticSigners.push(wallet.address)
+        //     const validatorSigner = await ethers.provider.getSigner(validator.signer)
+        //     await MaticStakeManager.connect(validatorSigner).updateSigner(i, signerPubKey)
+        //     await hre.network.provider.request({
+        //         method: "hardhat_stopImpersonatingAccount",
+        //         params: [validator.signer],
+        //     });
+        // }
+    })
+
+    before('deploy Tenderizer', async () => {
+        process.env.NAME = 'Matic'
+        process.env.SYMBOL = 'MATIC'
+        process.env.CONTRACT = MATIC_STAKE_MANAGER
+        process.env.VALIDATOR = VALIDATOR_SHARE
+        process.env.TOKEN = MATIC_TOKEN
+        process.env.STEAK_AMOUNT = STEAK_AMOUNT
+        process.env.ADMIN_FEE = '0'
+        process.env.SWAP_FEE = '5000000'
+        process.env.AMPLIFIER = '85'
+
+        // Deploy fixture
+        // Matic = await hre.deployments.fixture(['Matic'], {
+        //     keepExistingDeployments: true
+        // })
+
+        // comment out when 'keepExistingDeployments = false'
+
+        Tenderizer = (await ethers.getContractAt('Matic', '0xe07c344cB6a2Af8Fdf1d64c67D4C33a133fE7289')) as Matic
+        ValidatorShare = (await ethers.getContractAt('IMatic', await Tenderizer.node())) as IMatic
+
+        await hre.network.provider.request({
+            method: 'hardhat_impersonateAccount',
+            params: [TENDERIZE_OWNER]
+        })
+        await signers[0].sendTransaction({
+            to: TENDERIZE_OWNER,
+            value: ethers.utils.parseEther("1")
+        })
+        const deployerSigner = ethers.provider.getSigner(TENDERIZE_OWNER)
+        const newMatic = await (await ethers.getContractFactory('Matic', deployerSigner)).deploy()
+        const proxy = (await ethers.getContractAt('EIP173Proxy', Tenderizer.address)) as EIP173Proxy
+        await proxy.connect(deployerSigner).upgradeToAndCall(newMatic.address, Tenderizer.interface.encodeFunctionData('setWithdrawLockStart', [2]))
+    })
+
+    describe('Check Tenderize withdraw locks match Matic withdraw locks', async () => {
+        const UNSTAKE_AMOUNT =
+            before(async () => {
+                await MaticToken.approve(Tenderizer.address, ethers.utils.parseEther(STEAK_AMOUNT))
+                await Tenderizer.deposit(ethers.utils.parseEther(STEAK_AMOUNT), { gasLimit: 500000 })
+                await Tenderizer.claimRewards()
+            })
+
+        it('matches withdrawal lock ids for Tenderize and Matic', async () => {
+            const tenderizeID = await Tenderizer.callStatic.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
+            await Tenderizer.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
+            const maticID = await ValidatorShare.unbondNonces(Tenderizer.address)
+            expect(tenderizeID.toNumber()).to.eq(maticID.toNumber())
+        })
+    })
+
+})

--- a/test/mainnet/matic.test.ts
+++ b/test/mainnet/matic.test.ts
@@ -1,15 +1,13 @@
 // external imports
-import hre, { ethers, config } from 'hardhat'
+import hre, { ethers } from 'hardhat'
 
 // local imports
-import { ERC20, IMaticStakeManager, Matic, IMatic, TenderToken, EIP173Proxy } from "../../typechain"
-
+import { ERC20, IMaticStakeManager, Matic, IMatic, EIP173Proxy } from '../../typechain'
 
 // types
-import { Deployment } from 'hardhat-deploy/dist/types'
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
-
+import { BigNumber } from 'ethers'
 
 // Config
 const TOKEN_HOLDER = '0x50d669f43b484166680ecc3670e4766cdb0945ce'
@@ -20,149 +18,174 @@ const ALCHEMY_URL = process.env.ALCHEMY_MAINNET
 const TENDERIZE_OWNER = '0x5542b58080FEE48dBE6f38ec0135cE9011519d96'
 
 describe('Matic Mainnet Fork Test', () => {
-    let MaticStakeManager: IMaticStakeManager
-    let ValidatorShare: IMatic
-    let MaticToken: ERC20
-    let Tenderizer: Matic
+  let MaticStakeManager: IMaticStakeManager
+  let ValidatorShare: IMatic
+  let MaticToken: ERC20
+  let Tenderizer: Matic
 
-    // let Matic: { [name: string]: Deployment }
+  // let Matic: { [name: string]: Deployment }
 
-    let signers: SignerWithAddress[]
-    let deployer: string
+  let signers: SignerWithAddress[]
+  let deployer: string
 
-    // Create new Matic signers
-    // ---------------------------
-    // const newMaticSigners = []
-    // const accounts: any = config.networks.hardhat.accounts;
+  // Create new Matic signers
+  // ---------------------------
+  // const newMaticSigners = []
+  // const accounts: any = config.networks.hardhat.accounts;
 
-    const VALIDATOR_ID: number = 8
-    let VALIDATOR_SHARE: string
+  const VALIDATOR_ID: number = 87
+  let VALIDATOR_SHARE: string
 
-    before('fork mainnet', async () => {
-        // Fork from mainnet
-        await hre.network.provider.request({
-            method: 'hardhat_reset',
-            params: [{
-                forking: {
-                    jsonRpcUrl: ALCHEMY_URL,
-                    blockNumber: 16239470
-                }
-            }]
-        })
+  before('fork mainnet', async () => {
+    // Fork from mainnet
+    await hre.network.provider.request({
+      method: 'hardhat_reset',
+      params: [{
+        forking: {
+          jsonRpcUrl: ALCHEMY_URL,
+          blockNumber: 16239470
+        }
+      }]
+    })
+  })
+
+  before('get signers', async () => {
+    const namedAccs = await hre.getNamedAccounts()
+    signers = await ethers.getSigners()
+
+    deployer = namedAccs.deployer
+  })
+
+  // Change all validator signers
+  before('set up Matic', async () => {
+    MaticToken = (await ethers.getContractAt('ERC20', MATIC_TOKEN)) as ERC20
+    MaticStakeManager = (await ethers.getContractAt('IMaticStakeManager', MATIC_STAKE_MANAGER)) as IMaticStakeManager
+
+    // Get tokens
+    await hre.network.provider.request({
+      method: 'hardhat_impersonateAccount',
+      params: [TOKEN_HOLDER]
+    })
+    await signers[0].sendTransaction({
+      to: TOKEN_HOLDER,
+      value: ethers.utils.parseEther('1')
+    })
+    await MaticToken.connect(await ethers.provider.getSigner(TOKEN_HOLDER)).transfer(deployer, ethers.utils.parseEther(STEAK_AMOUNT).mul(5))
+    await hre.network.provider.request({
+      method: 'hardhat_stopImpersonatingAccount',
+      params: [TOKEN_HOLDER]
     })
 
-    before('get signers', async () => {
-        const namedAccs = await hre.getNamedAccounts()
-        signers = await ethers.getSigners()
+    const validator = await MaticStakeManager.validators(VALIDATOR_ID)
+    VALIDATOR_SHARE = validator.contractAddress
+    ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
 
-        deployer = namedAccs.deployer
+    // Change validator signers
+    // ------------------------
+    // const validatorCount = (await MaticStakeManager.currentValidatorSetSize()).toNumber()
+
+    // for (let i = 0; i < 9; i++) {
+    //     // get signer
+    //     const validator = await MaticStakeManager.validators(i);
+    //     if (i === 8) {
+    //         VALIDATOR_SHARE = validator.contractAddress
+    //         VALIDATOR_ID = i
+    //         VALIDATOR_ADDRESS = validator.signer
+    //         ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
+    //     }
+
+    //     // impersonate
+    //     await hre.network.provider.request({
+    //         method: 'hardhat_impersonateAccount',
+    //         params: [validator.signer]
+    //     })
+    //     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${i}`);
+    //     const signerPubKey = wallet.publicKey
+    //     newMaticSigners.push(wallet.address)
+    //     const validatorSigner = await ethers.provider.getSigner(validator.signer)
+    //     await MaticStakeManager.connect(validatorSigner).updateSigner(i, signerPubKey)
+    //     await hre.network.provider.request({
+    //         method: "hardhat_stopImpersonatingAccount",
+    //         params: [validator.signer],
+    //     });
+    // }
+  })
+
+  before('deploy Tenderizer', async () => {
+    process.env.NAME = 'Matic'
+    process.env.SYMBOL = 'MATIC'
+    process.env.CONTRACT = MATIC_STAKE_MANAGER
+    process.env.VALIDATOR = VALIDATOR_SHARE
+    process.env.TOKEN = MATIC_TOKEN
+    process.env.STEAK_AMOUNT = STEAK_AMOUNT
+    process.env.ADMIN_FEE = '0'
+    process.env.SWAP_FEE = '5000000'
+    process.env.AMPLIFIER = '85'
+
+    // Deploy fixture
+    // Matic = await hre.deployments.fixture(['Matic'], {
+    //     keepExistingDeployments: true
+    // })
+
+    // comment out when 'keepExistingDeployments = false'
+
+    Tenderizer = (await ethers.getContractAt('Matic', '0xe07c344cB6a2Af8Fdf1d64c67D4C33a133fE7289')) as Matic
+    ValidatorShare = (await ethers.getContractAt('IMatic', await Tenderizer.node())) as IMatic
+  })
+
+  describe('Deploy upgrade to fix withdraw Locks', async () => {
+    before(async () => {
+      await hre.network.provider.request({
+        method: 'hardhat_impersonateAccount',
+        params: [TENDERIZE_OWNER]
+      })
+      await signers[0].sendTransaction({
+        to: TENDERIZE_OWNER,
+        value: ethers.utils.parseEther('1')
+      })
+      const deployerSigner = ethers.provider.getSigner(TENDERIZE_OWNER)
+      const newMatic = await (await ethers.getContractFactory('Matic', deployerSigner)).deploy()
+      const proxy = (await ethers.getContractAt('EIP173Proxy', Tenderizer.address)) as EIP173Proxy
+      await proxy.connect(deployerSigner).upgradeToAndCall(newMatic.address, Tenderizer.interface.encodeFunctionData('setWithdrawLockStart', [2]))
+      await hre.network.provider.request({
+        method: 'hardhat_stopImpersonatingAccount',
+        params: [TENDERIZE_OWNER]
+      })
+      await MaticToken.approve(Tenderizer.address, ethers.utils.parseEther(STEAK_AMOUNT))
+      await Tenderizer.deposit(ethers.utils.parseEther(STEAK_AMOUNT), { gasLimit: 500000 })
+      await Tenderizer.claimRewards()
     })
 
-    // Change all validator signers
-    before('set up Matic', async () => {
-        MaticToken = (await ethers.getContractAt('ERC20', MATIC_TOKEN)) as ERC20
-        MaticStakeManager = (await ethers.getContractAt('IMaticStakeManager', MATIC_STAKE_MANAGER)) as IMaticStakeManager
-
-        // Get tokens
-        await hre.network.provider.request({
-            method: 'hardhat_impersonateAccount',
-            params: [TOKEN_HOLDER]
-        })
-        await signers[0].sendTransaction({
-            to: TOKEN_HOLDER,
-            value: ethers.utils.parseEther("1")
-        })
-        await MaticToken.connect(await ethers.provider.getSigner(TOKEN_HOLDER)).transfer(deployer, ethers.utils.parseEther(STEAK_AMOUNT).mul(5))
-        await hre.network.provider.request({
-            method: "hardhat_stopImpersonatingAccount",
-            params: [TOKEN_HOLDER],
-        });
-
-        const validator = await MaticStakeManager.validators(VALIDATOR_ID);
-        VALIDATOR_SHARE = validator.contractAddress
-        ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
-
-
-        // Change validator signers
-        // ------------------------
-        // const validatorCount = (await MaticStakeManager.currentValidatorSetSize()).toNumber()
-
-        // for (let i = 0; i < 9; i++) {
-        //     // get signer
-        //     const validator = await MaticStakeManager.validators(i);
-        //     if (i === 8) {
-        //         VALIDATOR_SHARE = validator.contractAddress
-        //         VALIDATOR_ID = i
-        //         VALIDATOR_ADDRESS = validator.signer
-        //         ValidatorShare = (await ethers.getContractAt('IMatic', VALIDATOR_SHARE)) as IMatic
-        //     }
-
-        //     // impersonate
-        //     await hre.network.provider.request({
-        //         method: 'hardhat_impersonateAccount',
-        //         params: [validator.signer]
-        //     })
-        //     const wallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${i}`);
-        //     const signerPubKey = wallet.publicKey
-        //     newMaticSigners.push(wallet.address)
-        //     const validatorSigner = await ethers.provider.getSigner(validator.signer)
-        //     await MaticStakeManager.connect(validatorSigner).updateSigner(i, signerPubKey)
-        //     await hre.network.provider.request({
-        //         method: "hardhat_stopImpersonatingAccount",
-        //         params: [validator.signer],
-        //     });
-        // }
+    it('matches withdrawal lock ids for Tenderize and Matic', async () => {
+      const tenderizeID = await Tenderizer.callStatic.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
+      await Tenderizer.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
+      const maticID = await ValidatorShare.unbondNonces(Tenderizer.address)
+      expect(tenderizeID.toNumber()).to.eq(maticID.toNumber())
     })
 
-    before('deploy Tenderizer', async () => {
-        process.env.NAME = 'Matic'
-        process.env.SYMBOL = 'MATIC'
-        process.env.CONTRACT = MATIC_STAKE_MANAGER
-        process.env.VALIDATOR = VALIDATOR_SHARE
-        process.env.TOKEN = MATIC_TOKEN
-        process.env.STEAK_AMOUNT = STEAK_AMOUNT
-        process.env.ADMIN_FEE = '0'
-        process.env.SWAP_FEE = '5000000'
-        process.env.AMPLIFIER = '85'
+    it('allows claiming the outstanding lock with ID 0, corresponding to Matic lock 1', async () => {
+      const LOCK_OWNER = '0xa1ea52b245f7f3e29599c8c83a1016e09ddd2523'
+      const fxRate = await ValidatorShare.withdrawExchangeRate()
+      const fxRatePrec = BigNumber.from('10').pow(29)
+      const maticLock = await ValidatorShare.unbonds_new(Tenderizer.address, 1)
+      const amount = maticLock.shares.mul(fxRate).div(fxRatePrec)
+      await hre.network.provider.request({
+        method: 'hardhat_impersonateAccount',
+        params: [LOCK_OWNER]
+      })
+      await signers[0].sendTransaction({
+        to: LOCK_OWNER,
+        value: ethers.utils.parseEther('1')
+      })
+      const balBefore = await MaticToken.balanceOf(LOCK_OWNER)
+      await Tenderizer.connect(ethers.provider.getSigner(LOCK_OWNER)).withdraw(0)
+      await hre.network.provider.request({
+        method: 'hardhat_stopImpersonatingAccount',
+        params: [LOCK_OWNER]
+      })
 
-        // Deploy fixture
-        // Matic = await hre.deployments.fixture(['Matic'], {
-        //     keepExistingDeployments: true
-        // })
-
-        // comment out when 'keepExistingDeployments = false'
-
-        Tenderizer = (await ethers.getContractAt('Matic', '0xe07c344cB6a2Af8Fdf1d64c67D4C33a133fE7289')) as Matic
-        ValidatorShare = (await ethers.getContractAt('IMatic', await Tenderizer.node())) as IMatic
-
-        await hre.network.provider.request({
-            method: 'hardhat_impersonateAccount',
-            params: [TENDERIZE_OWNER]
-        })
-        await signers[0].sendTransaction({
-            to: TENDERIZE_OWNER,
-            value: ethers.utils.parseEther("1")
-        })
-        const deployerSigner = ethers.provider.getSigner(TENDERIZE_OWNER)
-        const newMatic = await (await ethers.getContractFactory('Matic', deployerSigner)).deploy()
-        const proxy = (await ethers.getContractAt('EIP173Proxy', Tenderizer.address)) as EIP173Proxy
-        await proxy.connect(deployerSigner).upgradeToAndCall(newMatic.address, Tenderizer.interface.encodeFunctionData('setWithdrawLockStart', [2]))
+      const balAfter = await MaticToken.balanceOf(LOCK_OWNER)
+      expect(balBefore.add(amount)).to.eq(balAfter)
     })
-
-    describe('Check Tenderize withdraw locks match Matic withdraw locks', async () => {
-        const UNSTAKE_AMOUNT =
-            before(async () => {
-                await MaticToken.approve(Tenderizer.address, ethers.utils.parseEther(STEAK_AMOUNT))
-                await Tenderizer.deposit(ethers.utils.parseEther(STEAK_AMOUNT), { gasLimit: 500000 })
-                await Tenderizer.claimRewards()
-            })
-
-        it('matches withdrawal lock ids for Tenderize and Matic', async () => {
-            const tenderizeID = await Tenderizer.callStatic.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
-            await Tenderizer.unstake(ethers.utils.parseEther(STEAK_AMOUNT).div(2))
-            const maticID = await ValidatorShare.unbondNonces(Tenderizer.address)
-            expect(tenderizeID.toNumber()).to.eq(maticID.toNumber())
-        })
-    })
-
+  })
 })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The `withdrawLockID` for `Tenderizer` starts at 0, but Matic contracts start their count at 1.
This results in a mismatch whereby locks can become unclaimable.


**How did you test each of these updates (required)**
Added a mainnet fork test that mimics the behaviour and performs the upgrade.
These tests fail without performing the upgrade.
